### PR TITLE
feat: added function determineWinner which handles result and suggest…

### DIFF
--- a/contract/ballot_block.sol
+++ b/contract/ballot_block.sol
@@ -10,24 +10,29 @@ pragma solidity >=0.7.0<0.9.0;
 
 
 contract ballot_block{
-
     bool isVotingStarted;
     bool isVotingEnded;
+    bool isTied;
     struct vote{
         address candidateAddress;
         uint256 timeStamp;
     }
-
+    address[] candidates;
     mapping(address=>vote) public votes;
-
+    mapping(address=>uint256) voteCount;
+    address winner;
     event startingVote(address startedby);
     event endingVote(address endedby);
     event AddVote(address indexed voter, address receiver, uint256 timeStamp);
+    event ReElecting(address[] winners);
+    event WinnerDetermined(address winner);
 
     constructor()
     {
         isVotingStarted=false;
         isVotingEnded=false;
+        isTied=false;
+        candidates = [0xdD870fA1b7C4700F2BD7f44238821C26f7392148, 0x583031D1113aD414F02576BD6afaBfb302140225];
     }
 
     function Start() external returns (bool)
@@ -56,7 +61,40 @@ contract ballot_block{
         // write your code here
     }
 
-    
+    function getWinner() external view returns (address FinalWinner) {
+        require(isVotingStarted, "Voting has not started yet");
+        require(isVotingEnded, "Voting has not ended yet");
+        require(!isTied, "Voting has ended up in a tie, re-election required");
+        return winner;
+    }
 
-
+    function determineWinner() internal {
+        uint256 maxVotes = 0;
+        uint256 tiedCandidatesCount = 0;
+        address[] memory tiedCandidates;
+        for (uint256 i = 0; i < candidates.length; i++) {
+            if (voteCount[candidates[i]] > maxVotes) {
+                maxVotes = voteCount[candidates[i]];
+                tiedCandidatesCount = 0;
+                tiedCandidates[0] = candidates[i];
+            } else if (voteCount[candidates[i]] == maxVotes) {
+                tiedCandidates[tiedCandidatesCount] = candidates[i];
+                tiedCandidatesCount++;
+            }
+        }
+        if (tiedCandidatesCount > 1) {
+            isTied = true; 
+            delete candidates;
+            for (uint256 i = 0; i < tiedCandidatesCount; i++) {
+                candidates[i] = tiedCandidates[i];
+            }
+            emit ReElecting(candidates);
+            isVotingStarted = false;
+            isVotingEnded = false; 
+            return;
+        }
+        winner = tiedCandidates[0];
+        emit WinnerDetermined(tiedCandidates[0]);
+        return;
+    }
 }


### PR DESCRIPTION
… re-election in tie situation


## Description

Added function determineWinner which calculates result and handle tie cases by suggesting re-election. The administrator can then start next round election by simply calling Start() on the will. Also added getWinner function which a view function. So, it doesn't charge gas fee to retrieve the winner after the successful election.

## Semver Changes

- [ ] Patch (bug fix, no new features)
- [x] Minor (new features, no breaking changes)
- [ ] Major (breaking changes)

## Issues

> #9 

## Checklist

- [x] I have read the [Contributing Guidelines](../Contributor_Guide/Contruting.md).

